### PR TITLE
直连 influxdb 模式，增加无法连接 influxdb 时，将数据存储在本地 sqlite 数据库中，当网络恢复，立刻将本地数据上传。

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(exclude=[]),
     include_package_data=True,
     license='MIT',
-    install_requires=['pendulum', 'logbook', 'redis', 'influxdb', 'msgpack-python'],
+    install_requires=['pendulum', 'logbook', 'redis', 'influxdb', 'msgpack-python', 'toml', 'u-msgpack-python'],
     entry_points={
         'console_scripts': [
             'ziyan_make=ziyan:main'


### PR DESCRIPTION
1. 修复数据传入 redis 时，入队前重新生成 Lua 脚本散列值的bug
2. 更改 influxdb 测试连接方式，将返回值改为 true 或 false，放弃唤起异常的做法
3. 增加 sqlite 的入队出队机制
4. 使用 u-msgpack-python 库，解包更加轻松